### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/presence.py
+++ b/presence.py
@@ -1,6 +1,5 @@
 import time, argparse, json, configparser, pprint
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import process, fuzz
 from pypresence import Presence
 
 # Functions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pypresence
-fuzzywuzzy
-python-Levenshtein
+rapidfuzz


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy